### PR TITLE
Add machine-readable roadmap manifest

### DIFF
--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -1,0 +1,29 @@
+title: Percona Kubernetes Operators Roadmap
+description: |
+  Public roadmap for Percona Kubernetes Operators: planned features, backlog,
+  and release status for Percona Operator for MongoDB (PSMDB), Percona Operator
+  for MySQL, Percona Operator for MySQL/Percona XtraDB Cluster (PXC), and
+  Percona Operator for PostgreSQL.
+url: https://github.com/orgs/percona/projects/10
+contribute_url: https://github.com/percona/roadmap
+last_updated: 2026-01-23
+
+operators:
+  - id: psmdb
+    name: Percona Operator for MongoDB
+    repo: https://github.com/percona/percona-server-mongodb-operator
+    docs: https://docs.percona.com/percona-operator-for-mongodb
+  - id: mysql
+    name: Percona Operator for MySQL
+    repo: https://github.com/percona/percona-server-mysql-operator
+    docs: https://docs.percona.com/percona-operator-for-mysql
+  - id: pxc
+    name: Percona Operator for MySQL / Percona XtraDB Cluster
+    repo: https://github.com/percona/percona-xtradb-cluster-operator
+    docs: https://docs.percona.com/percona-operator-for-mysql
+  - id: pg
+    name: Percona Operator for PostgreSQL
+    repo: https://github.com/percona/percona-postgresql-operator
+    docs: https://docs.percona.com/percona-operator-for-postgresql
+
+schema_version: "1.0"

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -20,7 +20,7 @@ operators:
   - id: pxc
     name: Percona Operator for MySQL / Percona XtraDB Cluster
     repo: https://github.com/percona/percona-xtradb-cluster-operator
-    docs: https://docs.percona.com/percona-operator-for-mysql
+    docs: https://docs.percona.com/percona-operator-for-mysql/pxc/
   - id: pg
     name: Percona Operator for PostgreSQL
     repo: https://github.com/percona/percona-postgresql-operator

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -16,7 +16,7 @@ operators:
   - id: mysql
     name: Percona Operator for MySQL
     repo: https://github.com/percona/percona-server-mysql-operator
-    docs: https://docs.percona.com/percona-operator-for-mysql
+    docs: https://docs.percona.com/percona-operator-for-mysql/ps/
   - id: pxc
     name: Percona Operator for MySQL / Percona XtraDB Cluster
     repo: https://github.com/percona/percona-xtradb-cluster-operator


### PR DESCRIPTION
Add roadmap.yaml for Percona Kubernetes Operators

Machine-readable manifest with title, description, canonical URL, and operators list (PSMDB, MySQL, PXC, PG) for discovery and tooling.